### PR TITLE
 weapon not work on first build load fix

### DIFF
--- a/Assets/MainGame - Scripts/WeaponSpawner.cs
+++ b/Assets/MainGame - Scripts/WeaponSpawner.cs
@@ -10,7 +10,7 @@ public class WeaponSpawner : MonoBehaviour
     public GameObject spear;
     public StatHandler stat;
 
-    // Start is called before the first frame update
+        
     private void OnEnable()
     {
         switch (ChoiceCarrier.ChosenWeapon)

--- a/Assets/WeaponScript.cs
+++ b/Assets/WeaponScript.cs
@@ -32,13 +32,22 @@ public class WeaponScript : MonoBehaviour
     {
         Instance = this;
         // fire = player.playerCont.Player.Fire; 
+        StartCoroutine(EnableFire());
+
+    }
+
+    IEnumerator EnableFire()
+    {
+        while (PlayerScript.Instance == null)
+        {
+        yield return null;
+        }
         fire = PlayerScript.Instance.playerCont.Player.Fire;
         fire.Enable();
         fire.performed += Fire;
         fire.canceled += FireCancel;
+        
     }
-
-
 
     private void OnDisable()
     {


### PR DESCRIPTION
I fixed the error where the weapon not work on first build load. it was because the weaponScript was trying to access player.instance when it did not exist. fixed by using a coroutine